### PR TITLE
Solution to SWTBot failing on Jenkins

### DIFF
--- a/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnetnew/AbstractNewWizardTest.java
+++ b/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnetnew/AbstractNewWizardTest.java
@@ -24,6 +24,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.swtbot.eclipse.finder.waits.Conditions;
+import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.ui.IWorkingSet;
 
@@ -76,8 +77,9 @@ public class AbstractNewWizardTest extends AbstractDotnetTest {
 				fail("Unable to get containing folder content");
 			}
 		}
+		bot.waitUntil(Conditions.widgetIsEnabled(bot.button("Finish")),60000);//delay to load templates
 		bot.button("Finish").click();
-		bot.waitUntil(Conditions.shellCloses(shell),30000);
+		bot.waitUntil(Conditions.shellCloses(shell),60000);//delay to build project
 		
 		IProject createdProject = root.getProject(projectName);
 		assertTrue("No .project file", createdProject.getFile(".project") != null);

--- a/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnetrun/TestRun.java
+++ b/org.eclipse.acute.SWTBotTests/src/org/eclipse/acute/SWTBotTests/dotnetrun/TestRun.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.acute.SWTBotTests.dotnetrun;
 
+import java.security.Timestamp;
 import java.util.List;
 
 import org.eclipse.acute.SWTBotTests.AbstractDotnetTest;
@@ -49,18 +50,11 @@ public class TestRun extends AbstractDotnetTest{
 		List<Tree> controls = new ChildrenControlFinder(
 				debugView.getWidget()).findControls(WidgetOfType.widgetOfType(Tree.class));
 		SWTBotTree tree = new SWTBotTree((Tree) controls.get(0));
-		
 		bot.waitUntil(new ICondition() {
 			@Override
 			public boolean test() throws Exception {
-				for(SWTBotTreeItem item : tree.getAllItems()) {
-					for (String node : item.expand().getNodes()) {
-						if(node.matches("<terminated, exit value: 0>dotnet exec")) {
-							return true;
-						}
-					}
-				}
-				return false;
+				SWTBotView consoleView = bot.viewByPartName("Console");
+				return consoleView.bot().label().getText().matches("<terminated> .* \\[\\.NET Core Project\\] dotnet exec");
 			}
 			@Override public void init(SWTBot bot) {
 				debugView.setFocus();
@@ -68,7 +62,7 @@ public class TestRun extends AbstractDotnetTest{
 			@Override
 			public String getFailureMessage() {
 				SWTBotView consoleView = bot.viewByPartName("Console");
-				return "Test program failed: "+ consoleView.bot().styledText().getText();
+				return "No termination found. the "+consoleView.bot().label().getText()+" console outputted: "+ consoleView.bot().styledText().getText();
 			}
 		},30000);
 		


### PR DESCRIPTION
- Longer wait time used for loading templates and projects
- Use Console title instead of debug text for seeing if project ends running