### PR TITLE
Issue #110 Difficult to debug dotnet path issue

### DIFF
--- a/org.eclipse.acute/src/org/eclipse/acute/AcutePreferencePage.java
+++ b/org.eclipse.acute/src/org/eclipse/acute/AcutePreferencePage.java
@@ -33,6 +33,7 @@ public class AcutePreferencePage extends PreferencePage implements IWorkbenchPre
 	private IPreferenceStore store;
 
 	private Text explicitDotnetPathText;
+	private Label versionLabel;
 
 	@Override
 	public void init(IWorkbench workbench) {
@@ -66,10 +67,18 @@ public class AcutePreferencePage extends PreferencePage implements IWorkbenchPre
 		}
 		File dotnetCommand = new File(explicitDotnetPathText.getText());
 		if (!dotnetCommand.exists() || !dotnetCommand.isFile()) {
-			setErrorMessage("Input a valid path to `dotnet` command");
+			setErrorMessage("Input a valid path to `dotnet` command executable");
 			return false;
 		} else if (!dotnetCommand.canExecute()) {
-			setErrorMessage("Inputted command is not executable");
+			setErrorMessage("Inputted path does not lead to an executable command");
+			return false;
+		}
+		String version = DotnetVersionUtil.getVersion(explicitDotnetPathText.getText());
+		if (!DotnetVersionUtil.isValidVersionFormat(version)) {
+			setErrorMessage("`dotnet --version` failed to return a version");
+			return false;
+		} else if (!DotnetVersionUtil.isValidVersionNumber(version)) {
+			setErrorMessage("`dotnet` version 2.0 or greater is required");
 			return false;
 		}
 		setErrorMessage(null);
@@ -101,6 +110,7 @@ public class AcutePreferencePage extends PreferencePage implements IWorkbenchPre
 		explicitDotnetPathText.setLayoutData(textIndent);
 		explicitDotnetPathText.addModifyListener(e -> {
 			setValid(isPageValid());
+			versionLabel.setText("Command version: " + DotnetVersionUtil.getVersion(explicitDotnetPathText.getText()));
 		});
 
 		Button browseButton = new Button(container, SWT.NONE);
@@ -113,6 +123,9 @@ public class AcutePreferencePage extends PreferencePage implements IWorkbenchPre
 				explicitDotnetPathText.setText(path);
 			}
 		}));
+		versionLabel = new Label(container, SWT.NONE);
+		versionLabel.setLayoutData(textIndent);
+		versionLabel.setEnabled(false);
 	}
 
 }

--- a/org.eclipse.acute/src/org/eclipse/acute/DotnetVersionUtil.java
+++ b/org.eclipse.acute/src/org/eclipse/acute/DotnetVersionUtil.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Lucas Bullen (Red Hat Inc.) - Initial implementation
+ *******************************************************************************/
+package org.eclipse.acute;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import org.eclipse.core.runtime.Platform;
+
+public class DotnetVersionUtil {
+
+	public static final int MINIMUM_MAJOR_VERSION = 2;
+
+	public static boolean isValidVersionFormat(String version) {
+		return !version.isEmpty() && version.matches("\\d+\\.\\d+\\.\\d+.*");
+	}
+
+	public static boolean isValidVersionNumber(String version) {
+		return getMajorVersionNumber(version) >= MINIMUM_MAJOR_VERSION;
+	}
+
+	public static int getMajorVersionNumber(String version) {
+		return Integer.parseInt(version.split("\\.")[0]);
+	}
+
+	public static String getVersion(String dotnetPath) {
+		try {
+			String[] command = new String[] { "/bin/bash", "-c", dotnetPath + " --version" };
+			if (Platform.getOS().equals(Platform.OS_WIN32)) {
+				command = new String[] { "cmd", "/c", "which dotnet" };
+			}
+			ProcessBuilder builder = new ProcessBuilder(command);
+			Process process = builder.start();
+
+			if (process.waitFor() == 0) {
+				try (BufferedReader in = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+					return in.readLine();
+				}
+			}
+		} catch (IOException | InterruptedException e) {
+			// Error will be caught with empty response
+		}
+		return "";
+	}
+}

--- a/org.eclipse.acute/src/org/eclipse/acute/OmnisharpStreamConnectionProvider.java
+++ b/org.eclipse.acute/src/org/eclipse/acute/OmnisharpStreamConnectionProvider.java
@@ -39,17 +39,21 @@ public class OmnisharpStreamConnectionProvider implements StreamConnectionProvid
 	public OmnisharpStreamConnectionProvider() {
 	}
 
+	private boolean showDotnetCommandError = true;
+
 	@Override
 	public void start() throws IOException {
 		// workaround for https://github.com/OmniSharp/omnisharp-node-client/issues/265
 		try {
-			Process restoreProcess = Runtime.getRuntime().exec(new String[] { AcutePlugin.getDotnetCommand(), "restore" });
+			Process restoreProcess = Runtime.getRuntime().exec(new String[] { AcutePlugin.getDotnetCommand(showDotnetCommandError), "restore" });
+			showDotnetCommandError = true;
 			try {
 				restoreProcess.waitFor();
 			} catch (InterruptedException e) {
 				AcutePlugin.logError(e);
 			}
 		} catch (IllegalStateException e) {
+			showDotnetCommandError = false;
 			AcutePlugin.getDefault().getLog().log(new Status(IStatus.ERROR,
 					AcutePlugin.getDefault().getBundle().getSymbolicName(),
 					"`dotnet restore` not performed!\n"

--- a/org.eclipse.acute/src/org/eclipse/acute/dotnetnew/DotnetNewAccessor.java
+++ b/org.eclipse.acute/src/org/eclipse/acute/dotnetnew/DotnetNewAccessor.java
@@ -62,6 +62,8 @@ public class DotnetNewAccessor {
 	 * @return Map<String, String>: Contains the short name, used to refer to the
 	 *         template in bash commands, as the key and the template's full name as
 	 *         the value.
+	 * @throws IllegalStateException
+	 *             If no `dotnet` path has been set
 	 */
 	public static List<Template> getTemplates() {
 		try {
@@ -102,7 +104,7 @@ public class DotnetNewAccessor {
 				}
 				return templates;
 			}
-		} catch (IllegalStateException | IOException e) {
+		} catch (IOException e) {
 			return Collections.emptyList();
 		}
 	}


### PR DESCRIPTION
 - Executable path is checked with `dotnet --version` in preferences
 - Version is shown in preferences
 - Link to preferences from new project wizard
 - If `dotnet` command is not found, more description is given to user
 - Applying preferences changes updates the new project display

Signed-off-by: Lucas Bullen <lbullen@redhat.com>