### PR TITLE
corrected command string for win32 environment

### DIFF
--- a/org.eclipse.acute/src/org/eclipse/acute/DotnetVersionUtil.java
+++ b/org.eclipse.acute/src/org/eclipse/acute/DotnetVersionUtil.java
@@ -36,7 +36,7 @@ public class DotnetVersionUtil {
 		try {
 			String[] command = new String[] { "/bin/bash", "-c", dotnetPath + " --version" };
 			if (Platform.getOS().equals(Platform.OS_WIN32)) {
-				command = new String[] { "cmd", "/c", "which dotnet" };
+				command = new String[] { "cmd", "/c", "\"" + dotnetPath + "\" --version" };
 			}
 			ProcessBuilder builder = new ProcessBuilder(command);
 			Process process = builder.start();


### PR DESCRIPTION
solves issue with eclipse running on "win32" not getting a version string from the dotnet executable indicated by the user.  

Tested on eclipse Version: Oxygen.2 (4.7.2)
Build id: M20171130-0510


![](https://user-images.githubusercontent.com/6503686/39648135-e8c19cec-4f8d-11e8-9231-09671696e39f.png)
